### PR TITLE
Organize test suite side menu structure

### DIFF
--- a/qa-admin/src/app/features/dashboard/dashboard.module.ts
+++ b/qa-admin/src/app/features/dashboard/dashboard.module.ts
@@ -6,6 +6,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatButtonModule } from '@angular/material/button';
+import { MatTreeModule } from '@angular/material/tree';
 import { DashboardRoutingModule } from './dashboard.routing';
 import { ShellComponent } from './shell/shell.component';
 
@@ -19,7 +20,8 @@ import { ShellComponent } from './shell/shell.component';
     MatToolbarModule,
     MatIconModule,
     MatListModule,
-    MatButtonModule
+    MatButtonModule,
+    MatTreeModule
   ]
 })
 export class DashboardModule {}

--- a/qa-admin/src/app/features/dashboard/shell/shell.component.html
+++ b/qa-admin/src/app/features/dashboard/shell/shell.component.html
@@ -7,6 +7,39 @@
       <a mat-list-item routerLink="/dashboard/roles">Role Management</a>
       <a mat-list-item routerLink="/dashboard/permissions">Permissions</a>
     </mat-nav-list>
+
+    <div style="padding: 8px 16px; font-weight: 600;">Suites</div>
+    <div style="padding: 0 16px 8px 16px;">
+      <button mat-stroked-button color="primary" (click)="addSuite()">+ Add Suite</button>
+    </div>
+
+    <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
+      <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+        <div class="mat-tree-node">
+          <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'toggle ' + node.name">
+            <mat-icon>folder</mat-icon>
+          </button>
+          <span style="cursor: default;">{{node.name}}</span>
+          <span class="spacer"></span>
+          <button mat-icon-button aria-label="Add case" (click)="addCase(node)"><mat-icon>add</mat-icon></button>
+          <button mat-icon-button aria-label="Rename suite" (click)="renameSuite(node)"><mat-icon>edit</mat-icon></button>
+          <button mat-icon-button aria-label="Delete suite" (click)="deleteSuite(node)"><mat-icon>delete</mat-icon></button>
+        </div>
+        <div [class.tree-inset]="true">
+          <ng-container matTreeNodeOutlet></ng-container>
+        </div>
+      </mat-nested-tree-node>
+
+      <mat-tree-node *matTreeNodeDef="let node">
+        <div class="mat-tree-node">
+          <mat-icon class="mat-icon-rtl-mirror">article</mat-icon>
+          <a style="margin-left: 8px; cursor: pointer;" (click)="openCase(node.suiteId, node)">{{node.name}}</a>
+          <span class="spacer"></span>
+          <button mat-icon-button aria-label="Rename case" (click)="renameCase(node)"><mat-icon>edit</mat-icon></button>
+          <button mat-icon-button aria-label="Delete case" (click)="deleteCase(node.suiteId, node)"><mat-icon>delete</mat-icon></button>
+        </div>
+      </mat-tree-node>
+    </mat-tree>
   </mat-sidenav>
   <mat-sidenav-content>
     <mat-toolbar color="primary" class="toolbar">

--- a/qa-admin/src/app/features/dashboard/shell/shell.component.scss
+++ b/qa-admin/src/app/features/dashboard/shell/shell.component.scss
@@ -20,3 +20,7 @@
   width: 240px;
 }
 
+.tree-inset {
+  margin-left: 24px;
+}
+

--- a/qa-admin/src/app/features/dashboard/shell/shell.component.ts
+++ b/qa-admin/src/app/features/dashboard/shell/shell.component.ts
@@ -1,4 +1,19 @@
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { NestedTreeControl } from '@angular/cdk/tree';
+import { MatTreeNestedDataSource } from '@angular/material/tree';
+import { combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { MockDbService } from '../../../core/mock-db.service';
+import { TestCase, TestSuite } from '../../../core/models';
+
+interface SuiteCaseNode {
+  type: 'suite' | 'case';
+  id: string;
+  name: string;
+  suiteId?: string; // present when node is a case
+  children?: SuiteCaseNode[];
+}
 
 @Component({
   selector: 'app-shell',
@@ -7,5 +22,66 @@ import { Component } from '@angular/core';
 })
 export class ShellComponent {
   isOpened = true;
+  treeControl: NestedTreeControl<SuiteCaseNode> = new NestedTreeControl<SuiteCaseNode>((node: SuiteCaseNode) => node.children || []);
+  dataSource: MatTreeNestedDataSource<SuiteCaseNode> = new MatTreeNestedDataSource<SuiteCaseNode>();
+
+  constructor(private router: Router, private db: MockDbService) {
+    combineLatest([this.db.suites$, this.db.cases$]).pipe(
+      map(([suites, cases]: [TestSuite[], TestCase[]]) =>
+        suites.map((s: TestSuite) => ({
+          type: 'suite' as const,
+          id: s.id,
+          name: s.name,
+          children: s.caseIds
+            .map((id: string) => cases.find((c: TestCase) => c.id === id))
+            .filter((c): c is TestCase => Boolean(c))
+            .map((c: TestCase) => ({ type: 'case' as const, id: c.id, name: c.name, suiteId: s.id }))
+        }))
+      )
+    ).subscribe((data: SuiteCaseNode[]) => {
+      this.dataSource.data = data;
+    });
+  }
+
+  hasChild = (_: number, node: SuiteCaseNode): boolean => !!node.children && node.children.length > 0;
+
+  // Actions
+  addSuite(): void {
+    const name = prompt('New Suite name');
+    if (name && name.trim()) this.db.addSuite(name.trim());
+  }
+
+  renameSuite(node: SuiteCaseNode): void {
+    const name = prompt('Rename suite', node.name);
+    if (name && name.trim()) this.db.renameSuite(node.id, name.trim());
+  }
+
+  deleteSuite(node: SuiteCaseNode): void {
+    const ok = confirm(`Delete suite "${node.name}" and its cases?`);
+    if (ok) this.db.deleteSuite(node.id);
+  }
+
+  addCase(suiteNode: SuiteCaseNode): void {
+    const name = prompt('New Test Case name');
+    if (name && name.trim()) this.db.addCase(suiteNode.id, name.trim());
+  }
+
+  renameCase(caseNode: SuiteCaseNode): void {
+    const name = prompt('Rename case', caseNode.name);
+    if (name && name.trim()) this.db.renameCase(caseNode.id, name.trim());
+  }
+
+  deleteCase(suiteNodeOrId: SuiteCaseNode | string | undefined, caseNode: SuiteCaseNode): void {
+    const suiteId = typeof suiteNodeOrId === 'string' ? suiteNodeOrId : suiteNodeOrId?.suiteId || suiteNodeOrId?.id || caseNode.suiteId;
+    if (!suiteId) return;
+    const ok = confirm(`Delete test case "${caseNode.name}"?`);
+    if (ok) this.db.deleteCase(suiteId, caseNode.id);
+  }
+
+  openCase(suiteNodeOrId: SuiteCaseNode | string | undefined, caseNode: SuiteCaseNode): void {
+    const suiteId = typeof suiteNodeOrId === 'string' ? suiteNodeOrId : suiteNodeOrId?.suiteId || suiteNodeOrId?.id || caseNode.suiteId;
+    if (!suiteId) return;
+    this.router.navigate(['/dashboard/tests/suite', suiteId, 'case', caseNode.id]);
+  }
 }
 


### PR DESCRIPTION
Implement a nested sidebar menu for Test Suites and Test Cases with full CRUD operations and navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-70882a24-7684-402a-8c9b-ad9e488fd86e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70882a24-7684-402a-8c9b-ad9e488fd86e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

